### PR TITLE
coverage is optional.

### DIFF
--- a/tasks/mocha-chai-sinon.js
+++ b/tasks/mocha-chai-sinon.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
 	filterProjectSrc = filterProjectSrc.substr(filterProjectSrc.lastIndexOf('/'), filterProjectSrc.length) + '/src/';
 
 	require('blanket')({
-		pattern: grunt.config.data['mocha-chai-sinon'].coverage.options.filter || filterProjectSrc
+		pattern: grunt.config.data['mocha-chai-sinon'].coverage ? grunt.config.data['mocha-chai-sinon'].coverage.options.filter : filterProjectSrc
 	});
 
 


### PR DESCRIPTION
Fixed this error.

```
$ grunt test
Loading "mocha-chai-sinon.js" tasks...ERROR
>> TypeError: Cannot read property 'options' of undefined
Warning: Task "mocha-chai-sinon" not found. Use --force to continue.

Aborted due to warnings.
$
```
