### PR TITLE
Improve error logging

### DIFF
--- a/tasks/mocha-chai-sinon.js
+++ b/tasks/mocha-chai-sinon.js
@@ -69,11 +69,20 @@ module.exports = function(grunt) {
 			}
 
 		}, function(err, errCount) {
+
 			if (err) {
+
+				// logs error
+				grunt.log.error(err.stack);
+
 				done(false);
+
 			} else {
+
 				done(errCount === 0)
+
 			}
+
 		});
 
 	});


### PR DESCRIPTION
Hi!

This improves the error logging when the spec files have syntax errors or runtime errors outside of the outermost `describe` call (for example, mistakes in `require` call at the top). I guess the current version logs nothing in those situations.

Thanks,
